### PR TITLE
Fix to bring AnnotationTypes inline with the RAML 1.0 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ baseUri: https://www.example.com/{version}
 annotationTypes:
   - paging:
       allowedTargets: method
-      parameters:
+      properties:
         pageSize:
           type: pointer
           target: *.DataElement

--- a/java-raml1-parser/src/main/java/com/mulesoft/raml1/java/parser/impl/declarations/AnnotationTypeImpl.java
+++ b/java-raml1-parser/src/main/java/com/mulesoft/raml1/java/parser/impl/declarations/AnnotationTypeImpl.java
@@ -1,16 +1,16 @@
 package com.mulesoft.raml1.java.parser.impl.declarations;
 
-import java.util.List;
-import javax.xml.bind.annotation.XmlElement;
 import com.mulesoft.raml1.java.parser.core.JavaNodeFactory;
 import com.mulesoft.raml1.java.parser.impl.common.RAMLLanguageElementImpl;
-import com.mulesoft.raml1.java.parser.model.declarations.AnnotationType;
-import com.mulesoft.raml1.java.parser.model.datamodel.DataElement;
 import com.mulesoft.raml1.java.parser.impl.datamodel.DataElementImpl;
-import com.mulesoft.raml1.java.parser.model.declarations.AnnotationTarget;
-import com.mulesoft.raml1.java.parser.impl.declarations.AnnotationTargetImpl;
-import com.mulesoft.raml1.java.parser.model.systemTypes.MarkdownString;
 import com.mulesoft.raml1.java.parser.impl.systemTypes.MarkdownStringImpl;
+import com.mulesoft.raml1.java.parser.model.datamodel.DataElement;
+import com.mulesoft.raml1.java.parser.model.declarations.AnnotationTarget;
+import com.mulesoft.raml1.java.parser.model.declarations.AnnotationType;
+import com.mulesoft.raml1.java.parser.model.systemTypes.MarkdownString;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.List;
 
 
 
@@ -37,9 +37,9 @@ public class AnnotationTypeImpl extends RAMLLanguageElementImpl implements Annot
     }
 
 
-    @XmlElement(name="parameters")
-    public List<DataElement> parameters(){
-        return super.getElements("parameters", DataElementImpl.class);
+    @XmlElement(name="properties")
+    public List<DataElement> properties(){
+        return super.getElements("properties", DataElementImpl.class);
     }
 
 

--- a/java-raml1-parser/src/main/java/com/mulesoft/raml1/java/parser/model/declarations/AnnotationType.java
+++ b/java-raml1-parser/src/main/java/com/mulesoft/raml1/java/parser/model/declarations/AnnotationType.java
@@ -1,10 +1,11 @@
 package com.mulesoft.raml1.java.parser.model.declarations;
 
-import java.util.List;
-import javax.xml.bind.annotation.XmlElement;
 import com.mulesoft.raml1.java.parser.model.common.RAMLLanguageElement;
 import com.mulesoft.raml1.java.parser.model.datamodel.DataElement;
 import com.mulesoft.raml1.java.parser.model.systemTypes.MarkdownString;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.List;
 
 
 
@@ -18,8 +19,8 @@ public interface AnnotationType extends RAMLLanguageElement {
     String usage();
 
 
-    @XmlElement(name="parameters")
-    List<DataElement> parameters();
+    @XmlElement(name="properties")
+    List<DataElement> properties();
 
 
     @XmlElement(name="allowMultiple")

--- a/java-raml1-parser/src/main/resources/bundle.js
+++ b/java-raml1-parser/src/main/resources/bundle.js
@@ -2991,9 +2991,9 @@
 	    /**
 	     *
 	     **/
-	    //parameters
-	    AnnotationTypeImpl.prototype.parameters = function () {
-	        return _super.prototype.elements.call(this, 'parameters');
+	    //properties
+	    AnnotationTypeImpl.prototype.properties = function () {
+	        return _super.prototype.elements.call(this, 'properties');
 	    };
 	    /**
 	     *
@@ -20163,7 +20163,7 @@
 	                    if (x.key() == "annotations") {
 	                        return;
 	                    }
-	                    if (x.key() == "parameters") {
+	                    if (x.key() == "properties") {
 	                        return;
 	                    }
 	                    if (!pn.property(x.key())) {
@@ -30964,7 +30964,7 @@
 							"optional": false
 						},
 						{
-							"name": "parameters",
+							"name": "properties",
 							"type": {
 								"base": {
 									"typeName": "datamodel.DataElement",

--- a/java-raml1-parser/src/test/java/com/mulesoft/raml1/java/patser/test/Raml1Test.java
+++ b/java-raml1-parser/src/test/java/com/mulesoft/raml1/java/patser/test/Raml1Test.java
@@ -1,8 +1,5 @@
 package com.mulesoft.raml1.java.patser.test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
 import com.mulesoft.raml1.java.parser.core.JavaNodeFactory;
 import com.mulesoft.raml1.java.parser.model.api.Api;
 import com.mulesoft.raml1.java.parser.model.datamodel.DataElement;
@@ -11,6 +8,8 @@ import com.mulesoft.raml1.java.parser.model.datamodel.RAMLPointerElement;
 import com.mulesoft.raml1.java.parser.model.declarations.AnnotationType;
 import com.mulesoft.raml1.java.parser.model.methodsAndResources.Method;
 import com.mulesoft.raml1.java.parser.model.methodsAndResources.Resource;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,8 +18,8 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class Raml1Test
 {
@@ -84,12 +83,12 @@ public class Raml1Test
         final AnnotationType typePaging = api.annotationTypes().get(0);
         assertThat(typePaging.allowedTargets().size(), is(1));
         assertThat(typePaging.allowedTargets().get(0).value(), is("method"));
-        assertThat(typePaging.parameters().size(), is(2));
+        assertThat(typePaging.properties().size(), is(2));
 
-        annotationType((RAMLPointerElement) typePaging.parameters().get(0), "page-size",
+        annotationType((RAMLPointerElement) typePaging.properties().get(0), "page-size",
                        Collections.singletonList("pointer"),
                        "*.DataElement");
-        annotationType((RAMLPointerElement) typePaging.parameters().get(1), "offset",
+        annotationType((RAMLPointerElement) typePaging.properties().get(1), "offset",
                        Collections.singletonList("pointer"),
                        "*.DataElement");
     }

--- a/java-raml1-parser/src/test/resources/raml1.raml
+++ b/java-raml1-parser/src/test/resources/raml1.raml
@@ -5,7 +5,7 @@ baseUri: https://www.example.com/{version}
 annotationTypes:
   - paging:
       allowedTargets: method
-      parameters:
+      properties:
         page-size:
           type: pointer
           target: *.DataElement


### PR DESCRIPTION
Currently the parser is not inline with the current RAML 1.0 spec for AnnotationTypes.

Look at the example found in the parsers README.md

``` yaml
#%RAML 1.0
title: Samle API
version: v1.0
baseUri: https://www.example.com/{version}
annotationTypes:
  - paging:
      allowedTargets: method
      parameters:
        pageSize:
          type: pointer
          target: *.DataElement
        offset:
          type: pointer
          target: *.DataElement
```

Note that "parameters" is used as the name for the collection of annotation properties. In the RAML 1.0 spec this is actually "properties".

This pull request fixes this to come inline with the actual spec.
